### PR TITLE
bug: firefox: job position in list "jumps"

### DIFF
--- a/assets/themes/bootstrap/resources/bootstrap/css/style.css
+++ b/assets/themes/bootstrap/resources/bootstrap/css/style.css
@@ -210,7 +210,6 @@ text-decoration: underline;
   display: none;
 }  */
 .labelTag{
-  float:left;
   margin: 5px 5px 0px 0px;
   background: #E1ECF4;
   color: #39739d;
@@ -225,6 +224,7 @@ text-decoration: underline;
 .table>tfoot>tr>td {
 border-top: 1px solid #eee;
 }
+
 @media (min-width: 1280px){
   .well-lg-sp{
     height:180px;

--- a/assets/themes/bootstrap/resources/bootstrap/js/render_jobad_list_filter.js
+++ b/assets/themes/bootstrap/resources/bootstrap/js/render_jobad_list_filter.js
@@ -95,7 +95,6 @@ $(document).ready(function () {
  * @return {string} htmled detailed view of clicked row;
  */
 function detailFormatter(index, row) {
-    console.log(index);
     var html = [];
     var sourceName = "";
     var passUrl = "";


### PR DESCRIPTION
Dont know why float:left for labels was a problem for Firefox, but w/e. Anyway it is not needed now.